### PR TITLE
[skip ci] Update GHA badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Version](https://img.shields.io/pypi/v/nlpannotator)
 ![License: MIT](https://img.shields.io/github/license/ssciwr/argumentation-management)
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/ssciwr/argumentation-management/CI)
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/ssciwr/argumentation-management/ci.yml?branch=main)
 ![codecov](https://img.shields.io/codecov/c/github/ssciwr/argumentation-management)
 ![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ssciwr_argumentation-management&metric=alert_status)
 ![Language](https://img.shields.io/github/languages/top/ssciwr/argumentation-management)


### PR DESCRIPTION
There has been a backwards-incompatible change to shields.io badges for Github Actions. They now identify workflows by their filename instead of their name field.